### PR TITLE
Implement Exception Safety

### DIFF
--- a/src/external.rs
+++ b/src/external.rs
@@ -48,6 +48,7 @@ pub unsafe extern "C" fn new_file_handle_builder(
         base: FileHandle {
             layout: overall_layout,
             type_id: TypeId::of::<ExternalFileHandle>(),
+            poisoned: false,
             destroy: destroy_external_file_handle,
             write: write_external_file_handle,
             flush: flush_external_file_handle,

--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -5,7 +5,7 @@ use std::{
     ffi::CStr,
     fs::File,
     os::raw::{c_char, c_int},
-    panic, ptr,
+    ptr,
 };
 
 /// Create a new [`FileHandle`] which throws away all data written to it.
@@ -42,10 +42,8 @@ pub unsafe extern "C" fn new_file_handle_from_path(
 /// resources being used.
 #[no_mangle]
 pub unsafe extern "C" fn file_handle_destroy(handle: *mut FileHandle) {
-    let _ = panic::catch_unwind(|| {
-        let destructor = (*handle).destroy;
-        destructor(handle);
-    });
+    let destructor = (*handle).destroy;
+    destructor(handle);
 }
 
 /// Write some data to the file handle, returning the number of bytes written.
@@ -60,10 +58,9 @@ pub unsafe extern "C" fn file_handle_write(
     let write = (*handle).write;
     let data = std::slice::from_raw_parts(data as *const u8, len as usize);
 
-    match panic::catch_unwind(|| write(handle, data)) {
-        Ok(Ok(bytes_written)) => bytes_written as c_int,
-        Ok(Err(e)) => -e.raw_os_error().unwrap_or(1),
-        Err(_) => return -1,
+    match write(handle, data) {
+        Ok(bytes_written) => bytes_written as c_int,
+        Err(e) => -e.raw_os_error().unwrap_or(1),
     }
 }
 
@@ -75,10 +72,9 @@ pub unsafe extern "C" fn file_handle_write(
 pub unsafe extern "C" fn file_handle_flush(handle: *mut FileHandle) -> c_int {
     let flush = (*handle).flush;
 
-    match panic::catch_unwind(|| flush(handle)) {
-        Ok(Ok(_)) => 0,
-        Ok(Err(e)) => -e.raw_os_error().unwrap_or(1),
-        Err(_) => -1,
+    match flush(handle) {
+        Ok(_) => 0,
+        Err(e) => -e.raw_os_error().unwrap_or(1),
     }
 }
 

--- a/src/file_handle.rs
+++ b/src/file_handle.rs
@@ -1,7 +1,9 @@
 use std::{
     alloc::Layout,
-    any::TypeId,
-    io::{Error, Write},
+    any::{Any, TypeId},
+    fmt::{Display, Formatter},
+    io::{Error, ErrorKind, Write},
+    sync::Mutex,
 };
 
 /// A FFI-safe version of the trait object, [`dyn std::io::Write`][Write].
@@ -22,6 +24,7 @@ use std::{
 pub struct FileHandle {
     pub(crate) layout: Layout,
     pub(crate) type_id: TypeId,
+    pub(crate) poisoned: bool,
     pub(crate) destroy: unsafe fn(*mut FileHandle),
     pub(crate) write: unsafe fn(*mut FileHandle, &[u8]) -> Result<usize, Error>,
     pub(crate) flush: unsafe fn(*mut FileHandle) -> Result<(), Error>,
@@ -46,12 +49,13 @@ impl FileHandle {
     }
 
     fn vtable<W: Write + 'static>() -> FileHandle {
-        let layout = Layout::new::<W>();
+        let layout = Layout::new::<Repr<W>>();
         let type_id = TypeId::of::<W>();
 
         FileHandle {
             layout,
             type_id,
+            poisoned: false,
             destroy: destroy::<W>,
             write: write::<W>,
             flush: flush::<W>,
@@ -63,21 +67,86 @@ impl FileHandle {
 // `*mut Repr<W>`.
 
 unsafe fn destroy<W>(handle: *mut FileHandle) {
+    if handle.is_null() {
+        return;
+    }
+
     let repr = handle as *mut Repr<W>;
-    let _ = Box::from_raw(repr);
+
+    // Safety: If there was a panic it is no longer safe to call the object's
+    // destructor (it's probably FUBAR), but we can still reclaim the memory
+    // used by the original allocation.
+
+    if (*handle).poisoned {
+        let layout = (*handle).layout;
+        std::alloc::dealloc(repr.cast(), layout);
+    } else {
+        let _ = Box::from_raw(repr);
+    }
+}
+
+macro_rules! auto_poison {
+    ($handle:expr, $body:block) => {{
+        if (*$handle).poisoned {
+            Err(Error::new(
+                std::io::ErrorKind::InvalidData,
+                "A panic occurred and this object is now poisoned",
+            ))
+        } else {
+            let got = std::panic::catch_unwind(std::panic::AssertUnwindSafe(
+                move || $body,
+            ));
+            match got {
+                Ok(value) => value,
+                Err(payload) => {
+                    (*$handle).poisoned = true;
+                    Err(Error::new(ErrorKind::Other, Poisoned::from(payload)))
+                },
+            }
+        }
+    }};
 }
 
 unsafe fn write<W: Write>(
     handle: *mut FileHandle,
     data: &[u8],
 ) -> Result<usize, Error> {
-    let repr = &mut *(handle as *mut Repr<W>);
-    repr.writer.write(data)
+    auto_poison!(handle, {
+        let repr = &mut *(handle as *mut Repr<W>);
+        repr.writer.write(data)
+    })
 }
 
 unsafe fn flush<W: Write>(handle: *mut FileHandle) -> Result<(), Error> {
-    let repr = &mut *(handle as *mut Repr<W>);
-    repr.writer.flush()
+    auto_poison!(handle, {
+        let repr = &mut *(handle as *mut Repr<W>);
+        repr.writer.flush()
+    })
+}
+
+#[derive(Debug)]
+struct Poisoned(Mutex<Box<dyn Any + Send + 'static>>);
+
+impl From<Box<dyn Any + Send + 'static>> for Poisoned {
+    fn from(payload: Box<dyn Any + Send + 'static>) -> Self {
+        Poisoned(Mutex::new(payload))
+    }
+}
+
+impl std::error::Error for Poisoned {}
+
+impl Display for Poisoned {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        let payload = self.0.lock().unwrap();
+
+        if let Some(s) = payload.downcast_ref::<&str>() {
+            write!(f, "A panic occurred: {}", s)
+        } else if let Some(s) = payload.downcast_ref::<String>() {
+            write!(f, "A panic occurred: {}", s)
+        } else {
+            write!(f, "A panic occurred")
+        }
+    }
 }
 
 /// The "child class" which inherits from [`FileHandle`] and holds some type,


### PR DESCRIPTION
This is the code that would be required to implement "poisoning" in the face of panics, which we need because the FFI functions catch panics and let the `*mut FileHandle` be used later.

Unfortunately we need to add a `poisoned` flag which is checked in each vtable method instead of just FFI functions. Otherwise it is possible for a panic to occur when calling a function like `ffi::file_handle_write()` and the writer's internals get corrupted, then you pass the `*mut FileHandle` to Rust and try to call `OwnedFileHandle`'s `write()` method, letting you observe a FUBAR writer.

Fixes #1.